### PR TITLE
CLINAWS-608 - allow curators to view all provisional snapshots.

### DIFF
--- a/gci-vci-react/src/components/gene-central/GdmHeader.js
+++ b/gci-vci-react/src/components/gene-central/GdmHeader.js
@@ -7,6 +7,8 @@ import { useSelector, useDispatch } from "react-redux";
 import { Jumbotron, Container, Button, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencilAlt, faFileAlt, faTable, faBriefcase } from "@fortawesome/free-solid-svg-icons";
+import { getAffiliationName } from '../../helpers/get_affiliation_name.js';
+
 
 import { GdmDetails } from "./GdmDetails";
 import DiseaseModal from "../common/DiseaseModal";
@@ -205,8 +207,9 @@ export const GdmHeader = (props) => {
           <i>
             {gdm.modeInheritance} {gdm.modeInheritanceAdjective ? gdm.modeInheritanceAdjective : null}
           </i>
-          {!props.isSummary && allowEdit?
+          {!props.isSummary ?
             <>
+            {allowEdit ?
               <Link
                 to={`/curation-central/${gdm.PK}/gene-disease-evidence-summary/?preview=yes`}
                 target="_blank"
@@ -214,7 +217,12 @@ export const GdmHeader = (props) => {
               >
                 <Button>Preview Evidence Scored <FontAwesomeIcon icon={faFileAlt} /></Button>
               </Link>
-              <Button as={Link} to={`/provisional-curation/${gdm.PK}`} className="ml-1">View Classification Summary <FontAwesomeIcon icon={faTable} /></Button>
+              :
+                <OverlayTrigger overlay={<Tooltip>Previewing the evidence summary is restricted to the GCEP owner of the record</Tooltip>}>
+                  <Button className="ml-auto disabled">Preview Evidence Scored <FontAwesomeIcon icon={faFileAlt} /></Button>
+                </OverlayTrigger>
+             }
+            <Button as={Link} to={`/provisional-curation/${gdm.PK}`} className="ml-1">View Classification Summary <FontAwesomeIcon icon={faTable} /></Button>
             </>
             : null}
         </Row>
@@ -231,6 +239,6 @@ const DuplicateGdmAlertModalContent = ({ duplicatedGdm }) => {
   // duplicatedGdm object does not have disease object, only disease(string) and diseaseTerm(string)
   return (
     <>A curation record already exists for <strong>{lodashGet(duplicatedGdm, 'gene')} – {lodashGet(duplicatedGdm, 'diseaseTerm')} ({lodashGet(duplicatedGdm, 'disease')}) – {lodashGet(duplicatedGdm, 'modeInheritance')}</strong>.
-    You may curate this existing record, or cancel and change the disease for a different gene – disease – mode combination.</>
+    You may curate this existing record, or cancel and change the disease for a different gene
   )
 }

--- a/gci-vci-react/src/components/gene-central/GdmHeader.js
+++ b/gci-vci-react/src/components/gene-central/GdmHeader.js
@@ -239,6 +239,6 @@ const DuplicateGdmAlertModalContent = ({ duplicatedGdm }) => {
   // duplicatedGdm object does not have disease object, only disease(string) and diseaseTerm(string)
   return (
     <>A curation record already exists for <strong>{lodashGet(duplicatedGdm, 'gene')} – {lodashGet(duplicatedGdm, 'diseaseTerm')} ({lodashGet(duplicatedGdm, 'disease')}) – {lodashGet(duplicatedGdm, 'modeInheritance')}</strong>.
-    You may curate this existing record, or cancel and change the disease for a different gene
+    You may curate this existing record, or cancel and change the disease for a different gene – disease – mode combination.</>
   )
 }

--- a/gci-vci-react/src/components/provisional-classification/snapshots.js
+++ b/gci-vci-react/src/components/provisional-classification/snapshots.js
@@ -31,6 +31,7 @@ const Snapshots = (props) => {
         isApprovalActive,
         isPublishEventActive,
         classificationStatus,
+        allowEdit,
         allowPublishButton,
         showPublishLinkAlert,
         clearPublishLinkAlert,
@@ -278,7 +279,7 @@ const Snapshots = (props) => {
 
             // A classification snapshot must have same disease as current GDM and in supported SOP format to be approved or published
             diseaseMatched = snapshot.diseaseTerm === lodashGet(gdm, "disease.term", '');
-            allowToApprove = diseaseMatched && isSnapshotOnSupportedSOP;
+            allowToApprove = allowEdit && diseaseMatched && isSnapshotOnSupportedSOP;
         } else if (snapshot.resourceType === 'interpretation') {
             resourceParent = interpretation;
 
@@ -296,8 +297,14 @@ const Snapshots = (props) => {
         // Given snapshot is on the current supported SOP (isSnapshotOnSupportedSOP), has no publish activity (!snapshot.resource.publishDate) and
         // is the current approved (snapshot['@id'] === currentApprovedSnapshotID)
         const allowSnapshotPublish = diseaseMatched && isSnapshotOnSupportedSOP && !(lodashGet(snapshot, "resource.publishDate", null)) && snapshot.PK === currentApprovedSnapshotID;
+        // Add snapshot's affiliation as params to url which allows access to snapshots created by other affiliations
+        const params = new URLSearchParams(`snapshot=${snapshotPK}`)
+        if (affiliationID) {
+          params.append('affiliationId', affiliationID);
+        }
+
         const summaryLink = isGDM
-            ? `/curation-central/${resourceParent.PK}/gene-disease-evidence-summary/?snapshot=${snapshotPK}`
+            ? `/curation-central/${resourceParent.PK}/gene-disease-evidence-summary/?${params}`
             : `/snapshot-summary/?snapshot=${snapshotPK}`;
 
         if (snapshot.approvalStatus === 'Provisioned') {

--- a/gci-vci-react/src/components/recordStatus/approvalStatus.js
+++ b/gci-vci-react/src/components/recordStatus/approvalStatus.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import { Button } from 'react-bootstrap';
 
 import { sortListByDate } from '../../helpers/sort';
 import { Link } from 'react-router-dom';
@@ -78,7 +79,11 @@ function renderApprovalLink(snapshot, resourceType, affiliationId, userId, gdmPK
         summary_uri = '/snapshot-summary/'
     }
     if (snapshot) {
-        if (affiliationId && affiliationId.length) {
+        // Use the affiliation from the snapshot if exists since this affiliation is this snapshot's owner
+        if (snapshot.resource && snapshot.resource.affiliation) {
+            param.append('status', 'Approved');
+            param.append('affiliationId', snapshot.resource.affiliation);
+        } else if (affiliationId && affiliationId.length) {
             param.append('status', 'Approved');
             param.append('affiliationId', affiliationId);
         } else if (userId && userId.length) {
@@ -89,7 +94,7 @@ function renderApprovalLink(snapshot, resourceType, affiliationId, userId, gdmPK
     }
     return (
         <span className="classification-link-item ml-1">
-            <Link to={{ pathname: url }} title="View Current Approved" target="_blank"><i className="icon icon-link"></i></Link>
+            <Button variant="success" target="_blank" as={Link} to={url} className="ml-2">View Current Approved</Button>
         </span>
     );
 }

--- a/gci-vci-react/src/components/recordStatus/gdmClassificationStatus.js
+++ b/gci-vci-react/src/components/recordStatus/gdmClassificationStatus.js
@@ -32,11 +32,11 @@ export function renderClassificationStatus(classification, gdm, showProvisionalL
               {/* for `renderProvisionalStatus` and `renderNewProvisionalStatus`: pass in `isMyClassification` to determine whether the status link directs user to `provisional-classification` page for modifying status, or the read-only evidence summary page. */}
               {renderProvisionalStatus(snapshots, 'classification', gdm, showProvisionalLink, false, isMyClassification, affiliationId, userId)}
 
+              {renderPublishStatus(snapshots, 'classification')}
+
               {renderApprovalStatus(snapshots, 'classification', affiliationId, userId, false, gdm.PK)}
 
               {renderNewProvisionalStatus(snapshots, 'classification', gdm, showProvisionalLink, false, isMyClassification, affiliationId, userId)}
-
-              {renderPublishStatus(snapshots, 'classification')}
 
               <span>
                 {renderNewSummaryStatus(classification)}

--- a/gci-vci-react/src/components/recordStatus/provisionalStatus.js
+++ b/gci-vci-react/src/components/recordStatus/provisionalStatus.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import { Button } from 'react-bootstrap';
 
 import { sortListByDate } from '../../helpers/sort';
 import { Link } from 'react-router-dom';
@@ -96,6 +97,7 @@ export function renderProvisionalLink(snapshot, resourceType, gdm, isMyClassific
         // generate href and title
         let provisionalLinkHref;
         let provisionalLinkTitle;
+        // Even if isMyClassification, the snapshot might be created by another affiliation previously so link to read only
         if (!isMyClassification) {
             // render as others classification's link to evidence summary (read-only)
 
@@ -105,7 +107,10 @@ export function renderProvisionalLink(snapshot, resourceType, gdm, isMyClassific
 
             // add additional params
             const params = new URLSearchParams('status=Provisional')
-            if (affiliationId && affiliationId.length) {
+            // Use the affiliation from the snapshot if exists since this affiliation is this snapshot's owner
+            if (snapshot && snapshot.resource && snapshot.resource.affiliation) {
+                params.append('affiliationId', snapshot.resource.affiliation);
+            } else if (affiliationId && affiliationId.length) {
                 params.append('affiliationId', affiliationId);
             } else if (userId && userId.length) {
                 params.append('userId', userId);
@@ -127,7 +132,7 @@ export function renderProvisionalLink(snapshot, resourceType, gdm, isMyClassific
 
         return (
             <span className="classification-link-item ml-1">
-                <Link target={linkTarget} to={provisionalLinkHref} title={provisionalLinkTitle}><i className="icon icon-link"></i></Link>
+                <Button variant="info" target={linkTarget} as={Link} to={provisionalLinkHref} className="ml-2">{provisionalLinkTitle}</Button>
             </span>
         );
     } else if (resourceType === 'interpretation') {


### PR DESCRIPTION
This PR includes the following changes:
- On GCI landing page
   Disable "Preview Evidence Scored" button if logged in curator is not owner of the record.
   In Classifications section, move "PUBLISHED" icon in front of "APPROVED" icon.  Replace double-chain icon links to button links.
- On "View Classification Summary" page, if logged user is not record owner, cannot view matrix but allow to view the provisional/approved snapshots.