### PR TITLE
CLINAWS-653: fix display error on experimental data formta form

### DIFF
--- a/gci-vci-react/src/components/gene-central/curations/experimental-data/BiochemicalFunctionForm.js
+++ b/gci-vci-react/src/components/gene-central/curations/experimental-data/BiochemicalFunctionForm.js
@@ -1,11 +1,13 @@
 import React from "react";
 import Col from 'react-bootstrap/Col';
+import lodashGet from "lodash/get";
 
 import Input from '../../../common/Input';
 import CardPanel from '../../../common/CardPanel';
 import { dbxref_prefix_map } from '../../../common/globals';
 import { EXTERNAL_API_MAP } from '../../../../constants/externalApis';
 import { renderPhenotype } from '../../curations/common/commonFunc';
+import { getUserName } from "../../../../helpers/getUserName";
 import {
   Warning,
   HpoIdsLabel,
@@ -77,11 +79,9 @@ const BiochemicalFunctionForm = ({
         disabled
         rows="2"
         value={disease
-          ? !disease.freetext
-            ? disease.term + ' (' + disease.PK.replace('_', ':') + ')'
-            : disease.term + ' (' + auth && auth.name && auth.family_name
-              ? `${auth.name} ${auth.family_name}`
-              : auth && auth.email ? auth.email : ''
+          ? !lodashGet(disease, "freetext")
+            ? lodashGet(disease, "term", '') + ' (' + lodashGet(disease, "PK", '').replace('_', ':') + ')'
+            : lodashGet(disease, "term", '') + ' (' + getUserName(auth) + ')'
           : ''
         }
       />

--- a/gci-vci-react/src/pages/ExperimentalCuration.js
+++ b/gci-vci-react/src/pages/ExperimentalCuration.js
@@ -1096,6 +1096,7 @@ const ExperimentalCuration = ({
             </CardPanel>
             {formData && formData.experimentalType === 'Biochemical Function' && experimentalNameVisible &&
               <BiochemicalFunctionForm
+                auth={auth}
                 disease={disease}
                 uniprotId={uniprotId}
                 formData={formData}


### PR DESCRIPTION
This PR has two changes:

Add missing param auth when curating Biochemical function experimental data type.
When displaying disease term, make use of getUserName().