### PR TITLE
CLINAWS-660: GCI minor changes

### DIFF
--- a/gci-vci-react/src/components/provisional-classification/snapshots.js
+++ b/gci-vci-react/src/components/provisional-classification/snapshots.js
@@ -180,7 +180,7 @@ const Snapshots = (props) => {
                         snapshot.resource.approvalReviewDate ? snapshot.resource.approvalReviewDate : snapshot.resource.approvalDate;
                     publishAffiliation = snapshot.resource.publishAffiliation ? ' (' +
                         getAffiliationNameBySubgroupID('gcep', snapshot.resource.publishAffiliation) + ')' : '';
-                    publishSiteURL = 'https://search' + (demoVersion ? '-staging' : '') + '.clinicalgenome.org/kb/gene-validity/' +
+                    publishSiteURL = 'https://search' + (demoVersion ? '-staging' : '') + '.clinicalgenome.org/kb/gene-validity/CGGV:assertion_' +
                         snapshot.resource.PK + '--' + moment(publishSiteLinkDate).utc().format('Y-MM-DDTHH:mm:ss');
                     publishSiteLinkName = (resourceParent && resourceParent.gene && resourceParent.gene.symbol ?
                         resourceParent.gene.symbol + ' ' : '') + 'Classification Summary';

--- a/gci-vci-react/src/pages/ProvisionalCuration.js
+++ b/gci-vci-react/src/pages/ProvisionalCuration.js
@@ -34,7 +34,7 @@ class ProvisionalCuration extends Component {
     this.state = {
       user: null, // login user uuid
       gdm: null, // current gdm object, must be null initially.
-      allowEdit: true, // current gdm object can be edited by current logged in user
+      allowEdit: false, // current gdm object can be edited by current logged in user
       provisional: {}, // login user's existing provisional object, must be null initially.
       //assessments: null,  // list of all assessments, must be nul initially.
       totalScore: null,
@@ -201,9 +201,9 @@ class ProvisionalCuration extends Component {
           this.getClassificationSnapshots(stateObj.provisional);
         }
       }
-      // Set if current curator cannot edit this gdm
-      if ((gdmAffiliation && curatorAffiliation && gdmAffiliation !== curatorAffiliation.affiliation_id) || (!gdmAffiliation && !curatorAffiliation && gdm.submitted_by.PK !== stateObj.user)) {
-        this.setState({ allowEdit: false });
+      // Set if current curator can edit this GDM.  GDM needs to associated with a GCEP and user has to login as same GCEP in order to act on the GDM.
+      if (gdmAffiliation && curatorAffiliation && gdmAffiliation === curatorAffiliation.affiliation_id) {
+        this.setState({ allowEdit: true });
       }
     }
     this.calculateScoreTable();


### PR DESCRIPTION
Include two changes:

- Update link to the website so published classification can be linked to assertion on website

- Only allow GDM associated with an affiliation to be modified/acted on by user logged in as same affiliation