### PR TITLE
CLINAWS-661: Fix animal model only tag bug

### DIFF
--- a/gci-vci-react/src/helpers/render_classification_animal_only_tag.js
+++ b/gci-vci-react/src/helpers/render_classification_animal_only_tag.js
@@ -7,14 +7,16 @@ import React from 'react';
  */
 export function renderAnimalOnlyTag(provisional) {
     let classificationPoints = provisional.classificationPoints;
-    // Check if final classification is automatically calculated to "No Known Disease Relationship" and
+    // Check if final classification is automatically calculated to "No Known Disease Relationship" (no altered classification) and
     // only non-human points are scored in experimental evidence, then display Animal Model Only tag
-   if (provisional.autoClassification === 'No Known Disease Relationship' &&
-       classificationPoints && 
-       classificationPoints.modelsRescue && classificationPoints.modelsRescue.modelsNonHuman &&
-       classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven && 
-       classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven > 0 &&
-       classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven === classificationPoints.experimentalEvidenceTotal) {
+    const hasAltered = provisional.alteredClassification && provisional.alteredClassification !== 'No Modification';
+    if (!hasAltered &&
+        provisional.autoClassification === 'No Known Disease Relationship' &&
+        classificationPoints &&
+        classificationPoints.modelsRescue && classificationPoints.modelsRescue.modelsNonHuman &&
+         classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven &&
+         classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven > 0 &&
+         classificationPoints.modelsRescue.modelsNonHuman.totalPointsGiven === classificationPoints.experimentalEvidenceTotal) {
             return <span className="badge badge-warning">Animal Model Only</span>;
     }
     else {

--- a/gci-vci-serverless/src/helpers/messaging_helpers.py
+++ b/gci-vci-serverless/src/helpers/messaging_helpers.py
@@ -1218,10 +1218,12 @@ def add_contradictory_evidence(data, evidence, template):
 def add_animal_model_only(data, template):
   autoClassification = get_data_by_path(data, ['resource', 'autoClassification'], '')
   classificationPoints = get_data_by_path(data, ['resource', 'classificationPoints'], {})
+  alteredClassification = get_data_by_path(data, ['resource', 'alteredClassification'], 'No Modification')
 
-  # Check if final classification is automatically calculated to "No Known Disease Relationship"
+  # Check if final classification is automatically calculated to "No Known Disease Relationship" (no altered classification)
   # and only non-human points are scored in experimental evidence, then Animal Model Only tag is Yes
-  if (autoClassification == 'No Known Disease Relationship' and
+  if (alteredClassification == 'No Modification' and
+    autoClassification == 'No Known Disease Relationship' and
     classificationPoints['modelsRescue']['modelsNonHuman']['totalPointsGiven'] > 0 and
     classificationPoints['modelsRescue']['modelsNonHuman']['totalPointsGiven'] == classificationPoints['experimentalEvidenceTotal']):
     template['AnimalModelOnly'] = 'YES'


### PR DESCRIPTION
When determine Animal Model Only tag, add to check if there's no altered/modified classification.